### PR TITLE
Add thread follow-up handling for replyInThread mode

### DIFF
--- a/docs/specs/responses-api-migration/design.md
+++ b/docs/specs/responses-api-migration/design.md
@@ -7,20 +7,25 @@ Replace Chat Completions + Slack-stored message history with AI SDK
 
 ## High-Level Flow
 
-1. Receive mention event inputs (`channelId`, `message`).
+1. Receive event inputs (`channelId`, `message`, optional `eventType`).
 2. Trim mention and ignore empty content.
 3. Read conversation session record from datastore (`MessageHistory` on Slack).
 4. Resolve `systemMessage` from datastore (fallback to
    `env.INITIAL_SYSTEM_MESSAGE`).
-5. Resolve whether to include `previous_response_id` based on timeout.
-6. Call `generateText` with:
+5. Gate processing by event type and channel config:
+   - always process `app_mentioned`
+   - process `message_posted` only when `replyInThread=true`
+6. Resolve whether to include `previous_response_id` based on timeout.
+7. Call `generateText` / `streamText` with:
    - model: `openAI(env.GPT_MODEL)`
    - prompt: current user message
    - provider options:
      - `instructions`: system message
      - optional `previousResponseId`
-7. Post reply to Slack using `chat.postMessage`.
-8. Save latest `responseId` and timestamp to datastore (`MessageHistory` on
+8. Post reply to Slack:
+   - thread mode: Slack stream APIs
+   - channel mode: pseudo-stream (`chat.postMessage` + `chat.update`)
+9. Save latest `responseId` and timestamp to datastore (`MessageHistory` on
    Slack).
 
 ## Data Model
@@ -31,6 +36,7 @@ Replace Chat Completions + Slack-stored message history with AI SDK
 - `systemMessage`
 - `previousResponseId`
 - `lastInteractionAt` (unix epoch milliseconds)
+- `replyInThread`
 
 Slack datastore name must stay `MessageHistory` for backward compatibility.
 
@@ -38,14 +44,27 @@ Slack datastore name must stay `MessageHistory` for backward compatibility.
 
 ### Reply workflow
 
-- Remove `put_message_history` steps.
-- Pass original mention inputs directly to `stream_reply_function`.
+- Pass trigger inputs directly to `stream_reply_function`.
+- Include optional `eventType` to distinguish `app_mentioned` and
+  `message_posted` invocations.
+
+### Trigger configuration
+
+`configure_channels_modal_function` recreates event triggers per selected
+channel:
+
+- `app_mentioned` trigger for explicit mentions
+- `message_posted` trigger for follow-up thread replies without mention
+  - filter requires thread replies (non-null `thread_ts`)
 
 ### Stream reply function
 
-- Replace direct `fetch` streaming logic with AI SDK `generateText`.
-- Keep function callback id (`stream_reply_function`) for compatibility.
-- Use non-streaming Slack posting.
+- Keep callback id (`stream_reply_function`) for compatibility.
+- Use AI SDK with Responses API chaining.
+- Enforce event-type gate:
+  - ignore `message_posted` when channel is not in thread-reply mode
+- Thread mode uses Slack stream APIs.
+- Channel mode uses pseudo-streaming.
 
 ## Error Handling
 
@@ -58,5 +77,5 @@ Slack datastore name must stay `MessageHistory` for backward compatibility.
 
 - Keep Slack datastore name as `MessageHistory` to preserve existing production
   `systemMessage` values.
-- Mention trigger payload can still include extra fields; reply path depends on
-  `channelId` and `message`.
+- Maintain existing mention interaction while adding thread follow-up handling
+  through `message_posted`.

--- a/docs/specs/responses-api-migration/requirements.md
+++ b/docs/specs/responses-api-migration/requirements.md
@@ -47,6 +47,24 @@ construction.
 
 Session scope must be channel-based and keyed by `channelId`.
 
+### FR-8: Thread Follow-up Without Mention
+
+When `replyInThread` is enabled for a channel, the bot must respond to
+`message_posted` events in that channel's threads even when the message does
+not mention the bot.
+
+### FR-9: Event-Type-Aware Reply Gate
+
+The bot must keep mention-driven behavior as default, and process
+`message_posted` events only when `replyInThread` is enabled for that channel.
+
+### FR-10: Trigger Pair Management Per Channel
+
+Channel configuration must maintain event triggers as a pair per channel:
+
+- `app_mentioned` trigger (existing behavior)
+- `message_posted` trigger with filter for thread replies
+
 ## Non-Functional Requirements
 
 ### NFR-1: Backward Compatibility
@@ -54,6 +72,11 @@ Session scope must be channel-based and keyed by `channelId`.
 Existing mention trigger/workflow behavior should remain compatible from user
 perspective. Slack datastore name must remain `MessageHistory` so existing
 production `systemMessage` data is preserved.
+
+### NFR-4: Event Scope Completeness
+
+Manifest scopes must include permissions required by `message_posted` event
+triggers used by this app.
 
 ### NFR-2: Type Safety
 

--- a/docs/specs/responses-api-migration/requirements.md
+++ b/docs/specs/responses-api-migration/requirements.md
@@ -28,9 +28,13 @@ If elapsed time from the last interaction exceeds a configurable threshold
 (`RESPONSE_CHAIN_TIMEOUT_MINUTES`), the bot must start a new chain without
 `previous_response_id`.
 
-### FR-4: Non-Streaming Slack Reply
+### FR-4: Slack Reply Mode By Channel Setting
 
-The bot must post replies via `chat.postMessage` (non-streaming).
+The bot must select reply behavior by channel setting:
+
+- `replyInThread=true`: reply in thread using Slack stream APIs
+- `replyInThread=false`: reply in channel using pseudo-streaming
+  (`chat.postMessage` + `chat.update`)
 
 ### FR-5: System Message Preservation
 
@@ -50,8 +54,8 @@ Session scope must be channel-based and keyed by `channelId`.
 ### FR-8: Thread Follow-up Without Mention
 
 When `replyInThread` is enabled for a channel, the bot must respond to
-`message_posted` events in that channel's threads even when the message does
-not mention the bot.
+`message_posted` events in that channel's threads even when the message does not
+mention the bot.
 
 ### FR-9: Event-Type-Aware Reply Gate
 

--- a/docs/specs/responses-api-migration/tasks.md
+++ b/docs/specs/responses-api-migration/tasks.md
@@ -10,3 +10,9 @@
 - [x] Update README for Responses API-based behavior
 - [x] Run `deno check manifest.ts`
 - [x] Run related test suites
+- [ ] Add `message_posted` event trigger creation in channel configurator
+- [ ] Recreate configured channel triggers as mention + thread-followup pair
+- [ ] Add optional event type input to reply workflow/function path
+- [ ] Gate reply processing by `eventType` and `replyInThread`
+- [ ] Add manifest scopes required for `message_posted` trigger
+- [ ] Run `deno check manifest.ts` and related tests

--- a/docs/specs/responses-api-migration/tasks.md
+++ b/docs/specs/responses-api-migration/tasks.md
@@ -10,9 +10,9 @@
 - [x] Update README for Responses API-based behavior
 - [x] Run `deno check manifest.ts`
 - [x] Run related test suites
-- [ ] Add `message_posted` event trigger creation in channel configurator
-- [ ] Recreate configured channel triggers as mention + thread-followup pair
-- [ ] Add optional event type input to reply workflow/function path
-- [ ] Gate reply processing by `eventType` and `replyInThread`
-- [ ] Add manifest scopes required for `message_posted` trigger
-- [ ] Run `deno check manifest.ts` and related tests
+- [x] Add `message_posted` event trigger creation in channel configurator
+- [x] Recreate configured channel triggers as mention + thread-followup pair
+- [x] Add optional event type input to reply workflow/function path
+- [x] Gate reply processing by `eventType` and `replyInThread`
+- [x] Add manifest scopes required for `message_posted` trigger
+- [x] Run `deno check manifest.ts` and related tests

--- a/functions/configure_channels_modal/configure_channels_modal_function.ts
+++ b/functions/configure_channels_modal/configure_channels_modal_function.ts
@@ -24,10 +24,12 @@ export const ConfigureChannelsModalFunctionDefinition = DefineFunction({
 export default SlackFunction(
   ConfigureChannelsModalFunctionDefinition,
   async ({ inputs, client }) => {
-    const triggers = await findMentionTriggers(client);
-    const existingChannelIds = triggers.flatMap((trigger) =>
-      trigger.channel_ids
-    );
+    const triggers = await findReplyWorkflowEventTriggers(client);
+    const existingChannelIds = [
+      ...new Set(
+        triggers.flatMap((trigger) => trigger.channel_ids),
+      ),
+    ];
 
     const response = await client.views.open({
       interactivity_pointer: inputs.interactivityPointer,
@@ -43,22 +45,7 @@ export default SlackFunction(
 ).addViewSubmissionHandler(
   ["configure_channels_modal_view"],
   async ({ view, client }) => {
-    const triggers = await findMentionTriggers(client);
-
-    const obsoleteTriggers = triggers.filter((trigger) =>
-      trigger.channel_ids.length > 1
-    );
-    if (obsoleteTriggers.length > 0) {
-      console.log(`${obsoleteTriggers.length} obsolete triggers found`);
-      await Promise.all(
-        obsoleteTriggers.map((trigger) => deleteTrigger(client, trigger.id)),
-      );
-      console.log(
-        `💥 Obsolete triggers removed: ${
-          JSON.stringify(obsoleteTriggers.map((trigger) => trigger.id))
-        }`,
-      );
-    }
+    const triggers = await findReplyWorkflowEventTriggers(client);
 
     const inputChannelIds = view.state.values.channels_block.channel
       .selected_channels as string[];
@@ -66,20 +53,16 @@ export default SlackFunction(
       return { error: "Please select at least one channel" };
     }
 
-    const singleChannelTriggers = triggers.filter((trigger) =>
-      trigger.channel_ids.length === 1
-    );
-    if (singleChannelTriggers.length > 0) {
+    if (triggers.length > 0) {
       await Promise.all(
-        singleChannelTriggers.map((trigger) =>
-          deleteTrigger(client, trigger.id)
-        ),
+        triggers.map((trigger) => deleteTrigger(client, trigger.id)),
       );
       console.log(
-        `💥 Triggers removed: ${
+        `💥 Existing reply triggers removed: ${
           JSON.stringify(
-            singleChannelTriggers.map((trigger) => ({
+            triggers.map((trigger) => ({
               id: trigger.id,
+              event_type: trigger.event_type,
               channel_ids: trigger.channel_ids,
             })),
             null,
@@ -91,15 +74,25 @@ export default SlackFunction(
 
     const createResponse = await Promise.all(
       inputChannelIds.map((channelId) =>
-        createMentionTrigger(client, channelId)
+        createReplyTriggers(client, channelId)
       ),
     );
+    const createErrors = createResponse.filter((res) => res.error);
+    if (createErrors.length > 0) {
+      return {
+        error: `Failed to create triggers for all channels: ${
+          createErrors[0].error
+        }`,
+      };
+    }
+
     console.log(
       `✅ New triggers created: ${
         JSON.stringify(
-          createResponse.map((res) => ({
-            id: res.trigger?.id,
-            channel_ids: res.trigger?.channel_ids,
+          createResponse.flatMap((res) => res.triggers).map((trigger) => ({
+            id: trigger?.id,
+            event_type: trigger?.event_type,
+            channel_ids: trigger?.channel_ids,
           })),
           null,
           2,
@@ -166,7 +159,7 @@ const buildModalView = (channelIds: string[]) => ({
   ],
 });
 
-const findMentionTriggers = async (client: SlackAPIClient): Promise<
+const findReplyWorkflowEventTriggers = async (client: SlackAPIClient): Promise<
   EventTriggerResponseObject<typeof ReplyWorkflow.definition>[]
 > => {
   const allTriggers = await client.workflows.triggers.list({ is_owner: true });
@@ -174,31 +167,60 @@ const findMentionTriggers = async (client: SlackAPIClient): Promise<
     throw new Error("Failed to fetch triggers list");
   }
 
-  // Find app_mention event triggers to update
+  // Find reply workflow event triggers to update.
   const existingTriggers = allTriggers.triggers.filter((trigger) =>
     trigger.workflow.callback_id ===
       ReplyWorkflow.definition.callback_id &&
-    trigger.event_type === TriggerEventTypes.AppMentioned
+    (trigger.event_type === TriggerEventTypes.AppMentioned ||
+      trigger.event_type === TriggerEventTypes.MessagePosted)
   ) as EventTriggerResponseObject<typeof ReplyWorkflow.definition>[];
 
   return existingTriggers;
 };
 
-const createMentionTrigger = async (
+const createReplyTriggers = async (
   client: SlackAPIClient,
   channelId: string,
 ): Promise<{
+  error?: string;
+  triggers: EventTriggerResponseObject<typeof ReplyWorkflow.definition>[];
+}> => {
+  const mention = await createReplyTrigger(
+    client,
+    makeMentionTriggerConfig(channelId),
+  );
+  if (!mention.ok || !mention.trigger) {
+    return { error: mention.error, triggers: [] };
+  }
+
+  const threadFollowup = await createReplyTrigger(
+    client,
+    makeThreadFollowupTriggerConfig(channelId),
+  );
+  if (!threadFollowup.ok || !threadFollowup.trigger) {
+    await deleteTrigger(client, mention.trigger.id);
+    return { error: threadFollowup.error, triggers: [] };
+  }
+
+  return { triggers: [mention.trigger, threadFollowup.trigger] };
+};
+
+const createReplyTrigger = async (
+  client: SlackAPIClient,
+  config: ValidTriggerTypes<typeof ReplyWorkflow.definition>,
+): Promise<{
+  ok: boolean;
   error?: string;
   trigger?: EventTriggerResponseObject<typeof ReplyWorkflow.definition>;
 }> => {
   const createTriggerResponse = await client.workflows.triggers.create<
     typeof ReplyWorkflow.definition
-  >(makeMentionTriggerConfig(channelId));
+  >(config);
   if (!createTriggerResponse.ok) {
-    return { error: createTriggerResponse.error };
+    return { ok: false, error: createTriggerResponse.error };
   }
 
-  return { trigger: createTriggerResponse.trigger };
+  return { ok: true, trigger: createTriggerResponse.trigger };
 };
 
 const deleteTrigger = (client: SlackAPIClient, triggerId: string) =>
@@ -224,10 +246,71 @@ const makeMentionTriggerConfig = (channelId: string): ValidTriggerTypes<
       messageTs: {
         value: TriggerContextData.Event.AppMentioned.message_ts,
       },
+      eventType: {
+        value: TriggerContextData.Event.AppMentioned.event_type,
+      },
     },
     event: {
       event_type: TriggerEventTypes.AppMentioned,
       channel_ids: [channelId],
+    },
+  }
+);
+
+const makeThreadFollowupTriggerConfig = (
+  channelId: string,
+): ValidTriggerTypes<
+  typeof ReplyWorkflow.definition
+> => (
+  {
+    type: "event",
+    name: "thread follow-up trigger",
+    workflow: `#/workflows/${ReplyWorkflow.definition.callback_id}`,
+    inputs: {
+      channelId: {
+        value: TriggerContextData.Event.MessagePosted.channel_id,
+      },
+      message: {
+        value: TriggerContextData.Event.MessagePosted.text,
+      },
+      userId: {
+        value: TriggerContextData.Event.MessagePosted.user_id,
+      },
+      // Use parent ts so replies stay in the same thread.
+      messageTs: {
+        value: TriggerContextData.Event.MessagePosted.thread_ts,
+      },
+      eventType: {
+        value: TriggerContextData.Event.MessagePosted.event_type,
+      },
+    },
+    event: {
+      event_type: TriggerEventTypes.MessagePosted,
+      channel_ids: [channelId],
+      filter: {
+        version: 1,
+        root: {
+          operator: "AND",
+          inputs: [
+            {
+              operator: "NOT",
+              inputs: [
+                {
+                  statement: "{{data.thread_ts}} == null",
+                },
+              ],
+            },
+            {
+              operator: "NOT",
+              inputs: [
+                {
+                  statement: "{{data.user_id}} == null",
+                },
+              ],
+            },
+          ],
+        },
+      },
     },
   }
 );

--- a/functions/configure_channels_modal/configure_channels_modal_function.ts
+++ b/functions/configure_channels_modal/configure_channels_modal_function.ts
@@ -261,8 +261,13 @@ const makeThreadFollowupTriggerConfig = (
   channelId: string,
 ): ValidTriggerTypes<
   typeof ReplyWorkflow.definition
-> => (
-  {
+> => {
+  // Build filter statements from TriggerContextData constants to avoid
+  // hard-coded placeholder strings.
+  // Example value: "{{data.thread_ts}}"
+  const threadTs = TriggerContextData.Event.MessagePosted.thread_ts;
+  const userId = TriggerContextData.Event.MessagePosted.user_id;
+  return {
     type: "event",
     name: "thread follow-up trigger",
     workflow: `#/workflows/${ReplyWorkflow.definition.callback_id}`,
@@ -296,7 +301,7 @@ const makeThreadFollowupTriggerConfig = (
               operator: "NOT",
               inputs: [
                 {
-                  statement: "{{data.thread_ts}} == null",
+                  statement: `${threadTs} == null`,
                 },
               ],
             },
@@ -304,7 +309,7 @@ const makeThreadFollowupTriggerConfig = (
               operator: "NOT",
               inputs: [
                 {
-                  statement: "{{data.user_id}} == null",
+                  statement: `${userId} == null`,
                 },
               ],
             },
@@ -312,5 +317,5 @@ const makeThreadFollowupTriggerConfig = (
         },
       },
     },
-  }
-);
+  };
+};

--- a/functions/stream_reply/stream_reply_function.ts
+++ b/functions/stream_reply/stream_reply_function.ts
@@ -136,8 +136,6 @@ const toThreadTs = (
 
 const CHANNEL_PSEUDO_STREAM_MIN_APPEND_CHARS = 160;
 const CHANNEL_PSEUDO_STREAM_MIN_UPDATE_INTERVAL_MS = 800;
-const STREAM_MIN_APPEND_CHARS = 120;
-const STREAM_MIN_UPDATE_INTERVAL_MS = 1_000;
 
 const shouldFlushChannelPseudoStream = (
   pendingChars: number,
@@ -145,14 +143,6 @@ const shouldFlushChannelPseudoStream = (
 ): boolean => {
   return pendingChars >= CHANNEL_PSEUDO_STREAM_MIN_APPEND_CHARS ||
     elapsedMs >= CHANNEL_PSEUDO_STREAM_MIN_UPDATE_INTERVAL_MS;
-};
-
-const shouldFlushSlackStream = (
-  pendingChars: number,
-  elapsedMs: number,
-): boolean => {
-  return pendingChars >= STREAM_MIN_APPEND_CHARS ||
-    elapsedMs >= STREAM_MIN_UPDATE_INTERVAL_MS;
 };
 
 const normalizeEventType = (
@@ -184,7 +174,6 @@ export const streamReplyInternals = {
   getPreviousResponseId,
   toThreadTs,
   shouldFlushChannelPseudoStream,
-  shouldFlushSlackStream,
   normalizeEventType,
   shouldHandleEventType,
   hasAnyMentionToken,
@@ -375,14 +364,11 @@ export default SlackFunction(
       let streamTs: string | undefined;
       let streamStarted = false;
       let pending = "";
-      let pendingChars = 0;
-      let lastStreamAppendAt = Date.now();
 
       const appendStream = async () => {
         if (!streamTs || pending.length === 0) return;
         const text = pending;
         pending = "";
-        pendingChars = 0;
         const appendResponse = await client.apiCall("chat.appendStream", {
           channel: inputs.channelId,
           ts: streamTs,
@@ -396,7 +382,6 @@ export default SlackFunction(
             { streamStarted, partialReply: reply },
           );
         }
-        lastStreamAppendAt = Date.now();
       };
 
       for await (const chunk of streamResult.textStream) {
@@ -419,18 +404,11 @@ export default SlackFunction(
           }
           streamTs = startResponse.ts;
           streamStarted = true;
-          lastStreamAppendAt = Date.now();
           continue;
         }
 
         pending += chunk;
-        pendingChars += chunk.length;
-        const now = Date.now();
-        const elapsedMs = now - lastStreamAppendAt;
-        if (!shouldFlushSlackStream(pendingChars, elapsedMs)) {
-          continue;
-        }
-        if (pending.length > 0) {
+        if (pending.length >= 160) {
           await appendStream();
         }
       }

--- a/functions/stream_reply/stream_reply_function.ts
+++ b/functions/stream_reply/stream_reply_function.ts
@@ -26,6 +26,9 @@ export const StreamReplyFunctionDefinition = DefineFunction({
       messageTs: {
         type: Schema.slack.types.message_ts,
       },
+      eventType: {
+        type: Schema.types.string,
+      },
     },
     required: ["channelId", "systemMessage"],
   },
@@ -61,6 +64,21 @@ type ConversationSession = {
   previousResponseId?: string;
   lastInteractionAt?: number;
 };
+
+class StreamingReplyError extends Error {
+  streamStarted: boolean;
+  partialReply: string;
+
+  constructor(
+    message: string,
+    options?: { streamStarted?: boolean; partialReply?: string },
+  ) {
+    super(message);
+    this.name = "StreamingReplyError";
+    this.streamStarted = options?.streamStarted ?? false;
+    this.partialReply = options?.partialReply ?? "";
+  }
+}
 
 const trimMention = (message: string): string => {
   return message.replace(/<@.+>\s?/, "").trim();
@@ -118,6 +136,8 @@ const toThreadTs = (
 
 const CHANNEL_PSEUDO_STREAM_MIN_APPEND_CHARS = 160;
 const CHANNEL_PSEUDO_STREAM_MIN_UPDATE_INTERVAL_MS = 800;
+const STREAM_MIN_APPEND_CHARS = 120;
+const STREAM_MIN_UPDATE_INTERVAL_MS = 1_000;
 
 const shouldFlushChannelPseudoStream = (
   pendingChars: number,
@@ -127,19 +147,64 @@ const shouldFlushChannelPseudoStream = (
     elapsedMs >= CHANNEL_PSEUDO_STREAM_MIN_UPDATE_INTERVAL_MS;
 };
 
+const shouldFlushSlackStream = (
+  pendingChars: number,
+  elapsedMs: number,
+): boolean => {
+  return pendingChars >= STREAM_MIN_APPEND_CHARS ||
+    elapsedMs >= STREAM_MIN_UPDATE_INTERVAL_MS;
+};
+
+const normalizeEventType = (
+  eventType: string | undefined,
+): string | undefined => {
+  if (!eventType) return undefined;
+  const suffix = eventType.split("/").at(-1);
+  return suffix ?? eventType;
+};
+
+const shouldHandleEventType = (
+  eventType: string | undefined,
+  replyInThread: boolean,
+): boolean => {
+  const normalizedEventType = normalizeEventType(eventType);
+  if (!normalizedEventType || normalizedEventType === "app_mentioned") {
+    return true;
+  }
+  if (normalizedEventType === "message_posted") {
+    return replyInThread;
+  }
+  return true;
+};
+
+const hasAnyMentionToken = (text: string): boolean => /<@[A-Z0-9]+>/.test(text);
+
 export const streamReplyInternals = {
   getChainTimeoutMs,
   getPreviousResponseId,
   toThreadTs,
   shouldFlushChannelPseudoStream,
+  shouldFlushSlackStream,
+  normalizeEventType,
+  shouldHandleEventType,
+  hasAnyMentionToken,
 };
 
 export default SlackFunction(
   StreamReplyFunctionDefinition,
   async ({ inputs, client, env: slackEnv }) => {
+    const eventType = typeof inputs.eventType === "string"
+      ? inputs.eventType
+      : undefined;
+    const normalizedEventType = normalizeEventType(eventType);
+
     const content = trimMention(inputs.systemMessage);
     if (isBlank(content)) {
-      console.log("Skipping: StreamReplyFunction (empty message)");
+      console.log(
+        `Skipping: StreamReplyFunction (empty message, eventType=${
+          normalizedEventType ?? "unknown"
+        }, userId=${inputs.userId ?? "unknown"})`,
+      );
       return {
         outputs: {
           reply: "",
@@ -169,6 +234,43 @@ export default SlackFunction(
     const replyInThread = (sessionResponse.item?.replyInThread as
       | boolean
       | undefined) ?? false;
+    if (!shouldHandleEventType(eventType, replyInThread)) {
+      console.log(
+        `Skipping: StreamReplyFunction (eventType=${eventType}, replyInThread=${replyInThread})`,
+      );
+      return {
+        outputs: {
+          reply: "",
+        },
+      };
+    }
+    if (
+      normalizedEventType === "message_posted" &&
+      hasAnyMentionToken(inputs.systemMessage)
+    ) {
+      console.log(
+        "Skipping: StreamReplyFunction (message_posted with mention text)",
+      );
+      return {
+        outputs: {
+          reply: "",
+        },
+      };
+    }
+    if (normalizedEventType === "message_posted" && inputs.userId) {
+      const authTestResponse = await client.auth.test();
+      if (authTestResponse.ok && authTestResponse.user_id === inputs.userId) {
+        console.log(
+          "Skipping: StreamReplyFunction (message_posted from bot user)",
+        );
+        return {
+          outputs: {
+            reply: "",
+          },
+        };
+      }
+    }
+
     const previousResponseId = getPreviousResponseId(
       {
         previousResponseId: sessionResponse.item?.previousResponseId as
@@ -213,20 +315,32 @@ export default SlackFunction(
         );
         const reply =
           "Failed to generate a response. Please try again in a moment.";
+        try {
+          await client.chat.postMessage({
+            channel: inputs.channelId,
+            ...(options?.threadTs ? { thread_ts: options.threadTs } : {}),
+            text: reply,
+          });
+        } catch (_postError) {
+          // Ignore Slack posting errors in fallback path.
+        }
+        return { reply };
+      }
+
+      const reply = result.text;
+      try {
         await client.chat.postMessage({
           channel: inputs.channelId,
           ...(options?.threadTs ? { thread_ts: options.threadTs } : {}),
           text: reply,
         });
-        return { reply };
+      } catch (error) {
+        console.warn(
+          `Failed to post non-streaming Slack message: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
       }
-
-      const reply = result.text;
-      await client.chat.postMessage({
-        channel: inputs.channelId,
-        ...(options?.threadTs ? { thread_ts: options.threadTs } : {}),
-        text: reply,
-      });
       return {
         reply,
         responseId: extractResponseId(
@@ -259,24 +373,30 @@ export default SlackFunction(
 
       let reply = "";
       let streamTs: string | undefined;
+      let streamStarted = false;
       let pending = "";
+      let pendingChars = 0;
+      let lastStreamAppendAt = Date.now();
 
       const appendStream = async () => {
         if (!streamTs || pending.length === 0) return;
         const text = pending;
         pending = "";
+        pendingChars = 0;
         const appendResponse = await client.apiCall("chat.appendStream", {
           channel: inputs.channelId,
           ts: streamTs,
           markdown_text: text,
         }) as SlackStreamResponse;
         if (!appendResponse.ok) {
-          throw new Error(
+          throw new StreamingReplyError(
             `Failed to append Slack stream: ${
               appendResponse.error ?? "unknown_error"
             }`,
+            { streamStarted, partialReply: reply },
           );
         }
+        lastStreamAppendAt = Date.now();
       };
 
       for await (const chunk of streamResult.textStream) {
@@ -290,24 +410,36 @@ export default SlackFunction(
             markdown_text: chunk,
           }) as SlackStreamResponse;
           if (!startResponse.ok || !startResponse.ts) {
-            throw new Error(
+            throw new StreamingReplyError(
               `Failed to start Slack stream: ${
                 startResponse.error ?? "unknown_error"
               }`,
+              { streamStarted, partialReply: reply },
             );
           }
           streamTs = startResponse.ts;
+          streamStarted = true;
+          lastStreamAppendAt = Date.now();
           continue;
         }
 
         pending += chunk;
-        if (pending.length >= 160) {
+        pendingChars += chunk.length;
+        const now = Date.now();
+        const elapsedMs = now - lastStreamAppendAt;
+        if (!shouldFlushSlackStream(pendingChars, elapsedMs)) {
+          continue;
+        }
+        if (pending.length > 0) {
           await appendStream();
         }
       }
 
       if (!streamTs) {
-        throw new Error("No stream output produced.");
+        throw new StreamingReplyError(
+          "No stream output produced.",
+          { streamStarted, partialReply: reply },
+        );
       }
 
       await appendStream();
@@ -316,10 +448,11 @@ export default SlackFunction(
         ts: streamTs,
       }) as SlackStreamResponse;
       if (!stopResponse.ok) {
-        throw new Error(
+        throw new StreamingReplyError(
           `Failed to stop Slack stream: ${
             stopResponse.error ?? "unknown_error"
           }`,
+          { streamStarted, partialReply: reply },
         );
       }
 
@@ -447,10 +580,24 @@ export default SlackFunction(
         reply = streamOutcome.reply;
         responseId = streamOutcome.responseId;
       } catch (error) {
+        const streamError = error instanceof StreamingReplyError
+          ? error
+          : undefined;
+        const errorMessage = error instanceof Error
+          ? error.message
+          : String(error);
+        if (streamError?.streamStarted) {
+          console.warn(
+            `Streaming mode failed after stream started. Skipping fallback to avoid duplicate replies. Error: ${errorMessage}`,
+          );
+          return {
+            outputs: {
+              reply: streamError.partialReply,
+            },
+          };
+        }
         console.warn(
-          `Streaming mode failed. Falling back to non-streaming mode. Error: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Streaming mode failed before stream start. Falling back to non-streaming mode. Error: ${errorMessage}`,
         );
         const nonStreamingOutcome = await runNonStreaming({
           threadTs: replyInThread ? threadTs : undefined,

--- a/functions/stream_reply/stream_reply_function_test.ts
+++ b/functions/stream_reply/stream_reply_function_test.ts
@@ -58,3 +58,43 @@ Deno.test("shouldFlushChannelPseudoStream returns true on pending size", () => {
 Deno.test("shouldFlushChannelPseudoStream returns true on elapsed time", () => {
   assert(streamReplyInternals.shouldFlushChannelPseudoStream(1, 800));
 });
+
+Deno.test("shouldFlushSlackStream returns true on pending size", () => {
+  assert(streamReplyInternals.shouldFlushSlackStream(120, 0));
+});
+
+Deno.test("shouldFlushSlackStream returns true on elapsed time", () => {
+  assert(streamReplyInternals.shouldFlushSlackStream(1, 1_000));
+});
+
+Deno.test("shouldHandleEventType returns false for message_posted when channel mode", () => {
+  assertEquals(
+    streamReplyInternals.shouldHandleEventType("message_posted", false),
+    false,
+  );
+});
+
+Deno.test("shouldHandleEventType returns true for message_posted when thread mode", () => {
+  assertEquals(
+    streamReplyInternals.shouldHandleEventType("message_posted", true),
+    true,
+  );
+});
+
+Deno.test("shouldHandleEventType supports slack event namespace format", () => {
+  assertEquals(
+    streamReplyInternals.shouldHandleEventType(
+      "slack#/events/message_posted",
+      false,
+    ),
+    false,
+  );
+});
+
+Deno.test("hasAnyMentionToken detects mention token", () => {
+  assertEquals(
+    streamReplyInternals.hasAnyMentionToken("<@U123ABC45> hello"),
+    true,
+  );
+  assertEquals(streamReplyInternals.hasAnyMentionToken("hello"), false);
+});

--- a/functions/stream_reply/stream_reply_function_test.ts
+++ b/functions/stream_reply/stream_reply_function_test.ts
@@ -59,14 +59,6 @@ Deno.test("shouldFlushChannelPseudoStream returns true on elapsed time", () => {
   assert(streamReplyInternals.shouldFlushChannelPseudoStream(1, 800));
 });
 
-Deno.test("shouldFlushSlackStream returns true on pending size", () => {
-  assert(streamReplyInternals.shouldFlushSlackStream(120, 0));
-});
-
-Deno.test("shouldFlushSlackStream returns true on elapsed time", () => {
-  assert(streamReplyInternals.shouldFlushSlackStream(1, 1_000));
-});
-
 Deno.test("shouldHandleEventType returns false for message_posted when channel mode", () => {
   assertEquals(
     streamReplyInternals.shouldHandleEventType("message_posted", false),

--- a/manifest.ts
+++ b/manifest.ts
@@ -24,7 +24,6 @@ export default Manifest({
     "chat:write.public",
     "datastore:read",
     "datastore:write",
-    "groups:history",
     "triggers:read",
     "triggers:write",
   ],

--- a/manifest.ts
+++ b/manifest.ts
@@ -19,10 +19,12 @@ export default Manifest({
   datastores: [ConversationSessionDatastore],
   botScopes: [
     "app_mentions:read",
+    "channels:history",
     "chat:write",
     "chat:write.public",
     "datastore:read",
     "datastore:write",
+    "groups:history",
     "triggers:read",
     "triggers:write",
   ],

--- a/workflows/configure_channels_workflow.ts
+++ b/workflows/configure_channels_workflow.ts
@@ -5,7 +5,7 @@ export const ConfigureChannelsWorkflow = DefineWorkflow({
   callback_id: "configure_channels",
   title: "Select channels where ChagGPT bot works",
   description:
-    "Create or update an event trigger (subscribing an event type: `app_mentioned`) with specified channel IDs",
+    "Create or update event triggers (`app_mentioned` and `message_posted`) with specified channel IDs",
   input_parameters: {
     properties: {
       interactivity: { type: Schema.slack.types.interactivity },

--- a/workflows/reply_workflow.ts
+++ b/workflows/reply_workflow.ts
@@ -10,6 +10,7 @@ export const ReplyWorkflow = DefineWorkflow({
       message: { type: Schema.types.string },
       userId: { type: Schema.slack.types.user_id },
       messageTs: { type: Schema.slack.types.message_ts },
+      eventType: { type: Schema.types.string },
     },
     required: ["channelId", "message"],
   },
@@ -22,5 +23,6 @@ ReplyWorkflow.addStep(
     systemMessage: ReplyWorkflow.inputs.message,
     userId: ReplyWorkflow.inputs.userId,
     messageTs: ReplyWorkflow.inputs.messageTs,
+    eventType: ReplyWorkflow.inputs.eventType,
   },
 );


### PR DESCRIPTION
## Summary
- add spec updates for thread follow-up trigger support
- create per-channel trigger pair: app_mentioned + message_posted in channel configurator
- pass eventType through reply workflow and gate handling so message_posted is processed only when replyInThread=true
- skip duplicate paths for message_posted with mention text and bot-authored posts
- keep streaming fallback behavior safe: fallback to non-streaming only when stream failed before start, avoid duplicate replies after stream start
- use TriggerContextData constants in message_posted filter statements
- keep public-channel scope only (channels:history), remove groups:history

## Validation
- deno check manifest.ts
- deno test functions/stream_reply/stream_reply_function_test.ts
