### PR TITLE
Revert direct pushes for Responses tools changes

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -2,10 +2,7 @@
   "version": "4",
   "specifiers": {
     "jsr:@slack/api@2.9.0": "2.9.0",
-    "jsr:@std/collections@^1.0.5": "1.0.10",
-    "jsr:@std/http@0.206": "0.206.0",
-    "jsr:@std/jsonc@^1.0.1": "1.0.1",
-    "jsr:@std/path@^1.0.3": "1.0.6"
+    "jsr:@std/http@0.206": "0.206.0"
   },
   "jsr": {
     "@slack/api@2.9.0": {
@@ -14,22 +11,11 @@
         "jsr:@std/http"
       ]
     },
-    "@std/collections@1.0.10": {
-      "integrity": "903af106a3d92970d74e20f7ebff77d9658af9bef4403f1dc42a7801c0575899"
-    },
     "@std/http@0.206.0": {
       "integrity": "8e172a7129339fb80e7c9b36fc6bc6c0dd3f22d02c48b081d5dcfdc37cd1ea38"
-    },
-    "@std/jsonc@1.0.1": {
-      "integrity": "6b36956e2a7cbb08ca5ad7fbec72e661e6217c202f348496ea88747636710dda"
-    },
-    "@std/path@1.0.6": {
-      "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
     }
   },
   "remote": {
-    "https://deno.land/std@0.134.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
-    "https://deno.land/std@0.134.0/flags/mod.ts": "9bd361fd5487f5e06cae4e0b5237a83c2908202f4a76944ba1312029f6c11b95",
     "https://deno.land/std@0.224.0/assert/_constants.ts": "a271e8ef5a573f1df8e822a6eb9d09df064ad66a4390f21b3e31f820a38e0975",
     "https://deno.land/std@0.224.0/assert/assert.ts": "09d30564c09de846855b7b071e62b5974b001bb72a4b797958fe0660e7849834",
     "https://deno.land/std@0.224.0/assert/assert_almost_equals.ts": "9e416114322012c9a21fa68e187637ce2d7df25bcbdbfd957cd639e65d3cf293",
@@ -138,10 +124,6 @@
     "https://deno.land/x/deno_slack_api@2.9.3/typed-method-types/workflows/triggers/trigger-filter.ts": "db0583587e893b9dd4e30e1e413c5b177ac032c9053510bcdbd3d099b23130b6",
     "https://deno.land/x/deno_slack_api@2.9.3/typed-method-types/workflows/triggers/webhook.ts": "3aabfdc8daafd63dfe9db205811874256865130a31715d01117059c5bef6f351",
     "https://deno.land/x/deno_slack_api@2.9.3/types.ts": "bf747eb40d16c152f73c0e865f9e745990047236331fab179d6d0f69899324eb",
-    "https://deno.land/x/deno_slack_hooks@1.3.2/get_manifest.ts": "1eda87744f65d9bf0b81a0f3b8510657f40e6b2e7549bf843fc097a896c8686e",
-    "https://deno.land/x/deno_slack_hooks@1.3.2/utilities.ts": "536c5fb3551bb0b796534375ba3becf82c5e1aaa775daf747fd077b1f503d930",
-    "https://deno.land/x/deno_slack_protocols@0.0.2/deps.ts": "8ff2d185ecc28403588fdc108c58bb5d77181a67f209af29932ec1029cbf94e6",
-    "https://deno.land/x/deno_slack_protocols@0.0.2/mod.ts": "9de77fa9a0ccb7ca74b84e674c3fae7675ed487ff98a82d39a865f59f7df28e3",
     "https://deno.land/x/deno_slack_sdk@2.15.2/datastore/mod.ts": "0ebd6667a26e253c25c557ae1a091099d725d3fd940a07abddd11d8861aa8c58",
     "https://deno.land/x/deno_slack_sdk@2.15.2/datastore/types.ts": "73600c213b14bdd76cd7349c19fb01050dc8a4e4d94b5ad02bfcbc05d2a39039",
     "https://deno.land/x/deno_slack_sdk@2.15.2/deps.ts": "affcd19fdc0901250e632d696764d7f8c69d9bd52fb084d146de47ed45877b46",

--- a/docs/specs/responses-api-migration/design.md
+++ b/docs/specs/responses-api-migration/design.md
@@ -21,9 +21,6 @@ Responses API calls (`fetch`) using conversation chaining.
    - `input`: current user message
    - `instructions`: system message
    - optional `previous_response_id`
-   - optional `tools` from env flags
-     - `OPENAI_ENABLE_WEB_SEARCH` -> `{ "type": "web_search" }`
-     - `OPENAI_ENABLE_CODE_INTERPRETER` -> `{ "type": "code_interpreter" }`
    - `stream: true` when streaming/pseudo-streaming path is used
 8. Post reply to Slack:
    - thread mode: Slack stream APIs

--- a/docs/specs/responses-api-migration/tasks.md
+++ b/docs/specs/responses-api-migration/tasks.md
@@ -5,8 +5,6 @@
 - [x] Merge datastores into `ConversationSession` and include `systemMessage`
 - [x] Refactor `reply_workflow` to remove `put_message_history` steps
 - [x] Refactor `stream_reply_function` to use direct Responses API calls (fetch)
-- [x] Add optional Responses tools (`web_search`, `code_interpreter`) via env
-      flags
 - [x] Remove obsolete message history function from manifest/workflow path
 - [x] Update/add tests for session key and timeout logic
 - [x] Update README for Responses API-based behavior

--- a/env.ts.example
+++ b/env.ts.example
@@ -9,9 +9,5 @@ export const env = {
   SLACK_TEAM_ID: "TXXXXXXXXX",
   // Timeout for chaining responses via previous_response_id (minutes)
   RESPONSE_CHAIN_TIMEOUT_MINUTES: 30,
-  // Enable OpenAI Responses web search tool
-  OPENAI_ENABLE_WEB_SEARCH: true,
-  // Enable OpenAI Responses code interpreter tool
-  OPENAI_ENABLE_CODE_INTERPRETER: true,
   GPT_MODEL: "gpt-5-nano",
 };

--- a/functions/stream_reply/stream_reply_function.ts
+++ b/functions/stream_reply/stream_reply_function.ts
@@ -62,14 +62,9 @@ type OpenAIResponsesRequestInput = {
   prompt: string;
   instructions: string;
   previousResponseId?: string;
-  tools?: OpenAIResponseTool[];
 };
 
 const OPENAI_RESPONSES_API_URL = "https://api.openai.com/v1/responses";
-
-type OpenAIResponseTool = {
-  type: "web_search" | "code_interpreter";
-};
 
 class StreamingReplyError extends Error {
   streamStarted: boolean;
@@ -167,33 +162,6 @@ const extractResponseText = (payload: unknown): string => {
   return textParts.join("");
 };
 
-const extractToolCallTypes = (payload: unknown): string[] => {
-  if (!isRecord(payload)) return [];
-  const output = payload["output"];
-  if (!Array.isArray(output)) return [];
-
-  const toolTypes = new Set<string>();
-  for (const item of output) {
-    if (!isRecord(item)) continue;
-    const itemType = getStringField(item, "type");
-    if (itemType && itemType.endsWith("_call")) {
-      toolTypes.add(itemType);
-    }
-  }
-  return [...toolTypes];
-};
-
-const getConfiguredOpenAITools = (): OpenAIResponseTool[] => {
-  const tools: OpenAIResponseTool[] = [];
-  if (env.OPENAI_ENABLE_WEB_SEARCH) {
-    tools.push({ type: "web_search" });
-  }
-  if (env.OPENAI_ENABLE_CODE_INTERPRETER) {
-    tools.push({ type: "code_interpreter" });
-  }
-  return tools;
-};
-
 const buildOpenAIResponsesRequestBody = (
   input: OpenAIResponsesRequestInput,
   stream: boolean,
@@ -205,7 +173,6 @@ const buildOpenAIResponsesRequestBody = (
     ...(input.previousResponseId
       ? { previous_response_id: input.previousResponseId }
       : {}),
-    ...(input.tools && input.tools.length > 0 ? { tools: input.tools } : {}),
     ...(stream ? { stream: true } : {}),
   };
 };
@@ -239,7 +206,7 @@ const requestOpenAIResponses = async (
 
 const generateOpenAIResponse = async (
   input: OpenAIResponsesRequestInput,
-): Promise<{ reply: string; responseId?: string; toolCallTypes: string[] }> => {
+): Promise<{ reply: string; responseId?: string }> => {
   const response = await requestOpenAIResponses(input, false);
   const payload = await response.json() as OpenAIResponsesApiResponse;
   const reply = extractResponseText(payload);
@@ -249,14 +216,13 @@ const generateOpenAIResponse = async (
   return {
     reply,
     responseId: extractResponseId(payload),
-    toolCallTypes: extractToolCallTypes(payload),
   };
 };
 
 const streamOpenAIResponse = async (
   input: OpenAIResponsesRequestInput,
   onDelta: (delta: string) => Promise<void> | void,
-): Promise<{ reply: string; responseId?: string; toolCallTypes: string[] }> => {
+): Promise<{ reply: string; responseId?: string }> => {
   const response = await requestOpenAIResponses(input, true);
   if (!response.body) {
     throw new Error("OpenAI Responses API stream body is missing.");
@@ -266,7 +232,6 @@ const streamOpenAIResponse = async (
   let buffer = "";
   let reply = "";
   let responseId: string | undefined;
-  const toolCallTypes = new Set<string>();
 
   const processEventData = async (data: string) => {
     if (data.length === 0 || data === "[DONE]") {
@@ -303,20 +268,6 @@ const streamOpenAIResponse = async (
           reply = completedText;
           await onDelta(completedText);
         }
-      }
-      for (const toolCallType of extractToolCallTypes(responsePayload)) {
-        toolCallTypes.add(toolCallType);
-      }
-      return;
-    }
-
-    if (type && type.includes("_call")) {
-      const normalizedType = type.replace(/^response\./, "").replace(
-        /\.(in_progress|completed|delta)$/,
-        "",
-      );
-      if (normalizedType.endsWith("_call")) {
-        toolCallTypes.add(normalizedType);
       }
       return;
     }
@@ -369,7 +320,7 @@ const streamOpenAIResponse = async (
     throw new Error("OpenAI Responses API stream returned no output text.");
   }
 
-  return { reply, responseId, toolCallTypes: [...toolCallTypes] };
+  return { reply, responseId };
 };
 
 const toThreadTs = (
@@ -536,22 +487,14 @@ export default SlackFunction(
       model: env.GPT_MODEL,
       prompt: content,
       instructions: systemMessage,
-      tools: getConfiguredOpenAITools(),
       ...(previousResponseId ? { previousResponseId } : {}),
     };
-    console.log(
-      `Configured OpenAI tools: ${
-        openAIRequestInput.tools?.map((tool) => tool.type).join(", ") ??
-          "none"
-      }`,
-    );
 
     const runNonStreaming = async (
       options?: { threadTs?: string },
     ): Promise<{
       reply: string;
       responseId?: string;
-      toolCallTypes: string[];
     }> => {
       console.log("Slack reply mode: non-streaming");
       let result;
@@ -574,7 +517,7 @@ export default SlackFunction(
         } catch (_postError) {
           // Ignore Slack posting errors in fallback path.
         }
-        return { reply, toolCallTypes: [] };
+        return { reply };
       }
 
       const reply = result.reply;
@@ -594,7 +537,6 @@ export default SlackFunction(
       return {
         reply,
         responseId: result.responseId,
-        toolCallTypes: result.toolCallTypes,
       };
     };
 
@@ -610,7 +552,6 @@ export default SlackFunction(
     const runStreaming = async (): Promise<{
       reply: string;
       responseId?: string;
-      toolCallTypes: string[];
     }> => {
       console.log("Slack reply mode: streaming");
 
@@ -694,14 +635,12 @@ export default SlackFunction(
       return {
         reply: streamResult.reply,
         responseId: streamResult.responseId,
-        toolCallTypes: streamResult.toolCallTypes,
       };
     };
 
     const runChannelPseudoStreaming = async (): Promise<{
       reply: string;
       responseId?: string;
-      toolCallTypes: string[];
     }> => {
       console.log("Slack reply mode: pseudo-streaming in channel");
 
@@ -778,7 +717,6 @@ export default SlackFunction(
         return {
           reply: streamResult.reply,
           responseId: streamResult.responseId,
-          toolCallTypes: streamResult.toolCallTypes,
         };
       } catch (error) {
         console.warn(
@@ -795,20 +733,18 @@ export default SlackFunction(
         } catch (_fallbackSlackError) {
           // Ignore fallback posting errors and return a safe reply string.
         }
-        return { reply: fallbackReply, toolCallTypes: [] };
+        return { reply: fallbackReply };
       }
     };
 
     let reply: string;
     let responseId: string | undefined;
-    let toolCallTypes: string[] = [];
 
     if (canStream) {
       try {
         const streamOutcome = await runStreaming();
         reply = streamOutcome.reply;
         responseId = streamOutcome.responseId;
-        toolCallTypes = streamOutcome.toolCallTypes;
       } catch (error) {
         const streamError = error instanceof StreamingReplyError
           ? error
@@ -834,13 +770,11 @@ export default SlackFunction(
         });
         reply = nonStreamingOutcome.reply;
         responseId = nonStreamingOutcome.responseId;
-        toolCallTypes = nonStreamingOutcome.toolCallTypes;
       }
     } else if (!replyInThread) {
       const pseudoStreamingOutcome = await runChannelPseudoStreaming();
       reply = pseudoStreamingOutcome.reply;
       responseId = pseudoStreamingOutcome.responseId;
-      toolCallTypes = pseudoStreamingOutcome.toolCallTypes;
     } else {
       if (!streamTeamId) {
         console.log("Streaming disabled: SLACK_TEAM_ID is not configured.");
@@ -852,11 +786,6 @@ export default SlackFunction(
       });
       reply = nonStreamingOutcome.reply;
       responseId = nonStreamingOutcome.responseId;
-      toolCallTypes = nonStreamingOutcome.toolCallTypes;
-    }
-
-    if (toolCallTypes.length > 0) {
-      console.log(`OpenAI tools used: ${toolCallTypes.join(", ")}`);
     }
 
     if (!responseId) {

--- a/functions/stream_reply/stream_reply_function_test.ts
+++ b/functions/stream_reply/stream_reply_function_test.ts
@@ -121,7 +121,6 @@ Deno.test("buildOpenAIResponsesRequestBody includes previous_response_id", () =>
       prompt: "hello",
       instructions: "You are helpful.",
       previousResponseId: "resp_123",
-      tools: [{ type: "web_search" }],
     },
     true,
   );
@@ -130,6 +129,5 @@ Deno.test("buildOpenAIResponsesRequestBody includes previous_response_id", () =>
   assertEquals(body["input"], "hello");
   assertEquals(body["instructions"], "You are helpful.");
   assertEquals(body["previous_response_id"], "resp_123");
-  assertEquals(body["tools"], [{ type: "web_search" }]);
   assertEquals(body["stream"], true);
 });


### PR DESCRIPTION
This PR reverts two commits that were accidentally pushed directly to main:\n- 2d6aa4a Enable Responses tools for web search and code interpreter\n- 657c6c3 Document optional Responses tool settings\n\nAfter this lands, the same feature will be re-submitted via a normal review PR.